### PR TITLE
Fix tmp unbound variable at deploy.sh exit

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -126,9 +126,13 @@ install_fonts() {
   fi
   log "installing RobotoMono NerdFont ${FONT_VERSION}"
   local tmp; tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' RETURN
+  # Don't use `trap ... RETURN` for cleanup: bash's RETURN trap is shell-global,
+  # not function-scoped, so it would fire on every later function return with
+  # $tmp out of scope and trip `set -u`. Clean up inline; /tmp leaks on the
+  # curl/unzip failure path are self-cleaning via systemd-tmpfiles.
   ( cd "$tmp" && curl -LsSfO "$FONT_URL" && unzip -q RobotoMono.zip )
   mv "$tmp"/*.ttf "$fontdir"/
+  rm -rf "$tmp"
   if command -v fc-cache >/dev/null 2>&1; then
     fc-cache -f "$fontdir" >/dev/null 2>&1 || true
   fi


### PR DESCRIPTION
## Summary

`install_fonts` in `deploy.sh` used `trap 'rm -rf "$tmp"' RETURN` to clean up its temp dir. Bash's RETURN trap is shell-global, not function-scoped — once set, it fires on *every* subsequent function return. After `install_fonts` returns, the trap keeps re-firing with `$tmp` out of scope, and under `set -u` that trips `tmp: unbound variable`. Reported at the defining line of the function whose return triggered the trap, so the error surfaces as "line 249" (the line of `main() {`) at the very end of the run.

The script **does** complete its actual work first — the `==> done. open a new shell...` log prints before the trap error. So the crash is cosmetic (non-zero exit, confusing output), not destructive.

This only shows up when the font sentinel is absent (fresh install, or after a `FONT_VERSION` bump). Cached-font runs short-circuit before the trap is ever set, which is why earlier smoke tests didn't catch it.

## Fix

Drop the RETURN trap and `rm -rf "$tmp"` inline. Temp-dir leaks on the curl/unzip error path are acceptable — `/tmp` is reaped by systemd-tmpfiles.

## Reproduction

```bash
$ bash -c 'set -euo pipefail
f(){ local t; t=$(mktemp -d); trap "rm -rf \$t" RETURN; }
m(){ f; }
m
echo ok'
ok
bash: line 1: t: unbound variable
```

## Test plan

- [x] `bash -n deploy.sh` — syntax OK
- [x] Minimal repro confirms the bug on the pre-fix pattern and shows the post-fix pattern exits 0 cleanly
- [ ] Run `./deploy.sh` end-to-end once through the font-install path on a machine without the sentinel (user already re-ran with the sentinel present, so `install_fonts` now short-circuits — this box can't retest without manually deleting the sentinel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)